### PR TITLE
Update package version, restructure, and add DomainEvent

### DIFF
--- a/MBS-CONTRACT.SHARE/MBS-CONTRACT.SHARE.csproj
+++ b/MBS-CONTRACT.SHARE/MBS-CONTRACT.SHARE.csproj
@@ -10,7 +10,7 @@
 
     <PropertyGroup>
         <PackageId>MBS_CONTRACT.SHARE</PackageId>
-        <Version>1.1.1</Version>
+        <Version>1.1.2</Version>
         <Authors>bentran1vn</Authors>
         <Company>MBS_COMPANY</Company>
         <Description>A share library for MBS System !</Description>
@@ -23,7 +23,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Services\Slots\" />
       <None Include=".dockerignore" Pack="true" />
     </ItemGroup>
 

--- a/MBS-CONTRACT.SHARE/Services/Slots/DomainEvent.cs
+++ b/MBS-CONTRACT.SHARE/Services/Slots/DomainEvent.cs
@@ -1,0 +1,23 @@
+﻿using MBS_CONTRACT.SHARE.Abstractions.Messages;
+
+namespace MBS_CONTRACT.SHARE.Services.Slots;
+
+public static class DomainEvent
+{
+   //list of slot created
+   public record SlotsCreated(Guid IdEvent, List<SLot> Slots) : IDomainEvent, ICommand;
+
+   public class SLot
+   {
+      public Guid? MentorId { get; set; }
+      public TimeOnly StartTime { get; set; }
+      public TimeOnly EndTime { get; set; }
+      public DateOnly Date { get; set; }
+      public bool IsOnline { get; set; }
+      public string? Note { get; set; }
+      public short? Month { get; set; }
+      public bool IsBook { get; set; }
+      public DateTimeOffset CreatedOnUtc { get; set; }
+      public DateTimeOffset? ModifiedOnUtc { get; set; }
+    }
+}


### PR DESCRIPTION
Updated MBS_CONTRACT.SHARE package version from 1.1.1 to 1.1.2.
Commented out PackageReadmeFile property in MBS-CONTRACT.SHARE.csproj.
Removed Services\Slots\ folder from the project.
Added DomainEvent static class in DomainEvent.cs under MBS_CONTRACT.SHARE.Services.Slots namespace.
Included SlotsCreated record implementing IDomainEvent and ICommand.
Defined nested SLot class with various properties.